### PR TITLE
Support Laravel 9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,12 +16,12 @@
         }
     ],
     "require": {
-        "php": "^8.0",
+        "php": "^8.0|^8.1",
         "spatie/laravel-package-tools": "^1.9.2",
-        "illuminate/contracts": "^8.0"
+        "illuminate/contracts": "^8.0|^9.0"
     },
     "require-dev": {
-        "nunomaduro/collision": "^5.10",
+        "nunomaduro/collision": "^5.10|^6.1",
         "orchestra/testbench": "^6.0",
         "pestphp/pest": "^1.21",
         "phpunit/phpunit": "^9.5.10"


### PR DESCRIPTION
This PR adds support for Laravel 9. Attempts to install this package in Laravel 9 resulted in composer throwing the error `requires illuminate/contracts ^8.0`.