### PR TITLE
deposit and deduct from the wallet at the database level

### DIFF
--- a/src/Traits/HasWallet.php
+++ b/src/Traits/HasWallet.php
@@ -12,13 +12,9 @@ trait HasWallet
     {
         $this->throwExceptionIfAmountIsInvalid($amount);
 
-        $balance = $this->wallet_balance ?? 0;
+        $this->increment('wallet_balance', $amount);
 
-        $balance += $amount;
-
-        $this->forceFill(['wallet_balance' => $balance])->save();
-
-        return $balance;
+        return $this->wallet_balance;
     }
 
     public function withdraw(int|float $amount): float|int
@@ -27,11 +23,9 @@ trait HasWallet
 
         $this->throwExceptionIfFundIsInsufficient($amount);
 
-        $balance = $this->wallet_balance - $amount;
+        $this->decrement('wallet_balance', $amount);
 
-        $this->forceFill(['wallet_balance' => $balance])->save();
-
-        return $balance;
+        return $this->wallet_balance;
     }
 
     public function canWithdraw(int|float $amount): bool


### PR DESCRIPTION
It is possible that the package runs into race conditaions when multiple simultenous requests attemmpts to update the user wallet balance at the same time.

This [SO answer ](https://stackoverflow.com/a/71890092/13315661) does a good explanation of why I'm pushing for this adjustment.