### PR TITLE
Add support for Laravel 12 and 13

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,14 +13,21 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest, windows-latest]
-        php: [8.2, 8.3]
-        laravel: [10.*, 11.*]
+        php: [8.2, 8.3, 8.4]
+        laravel: [10.*, 11.*, 12.*, 13.*]
         stability: [prefer-stable]
         include:
           - laravel: 10.*
             testbench: 8.*
           - laravel: 11.*
             testbench: 9.*
+          - laravel: 12.*
+            testbench: 10.*
+          - laravel: 13.*
+            testbench: 11.*
+        exclude:
+          - laravel: 13.*
+            php: 8.2
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 

--- a/composer.json
+++ b/composer.json
@@ -16,15 +16,15 @@
         }
     ],
     "require": {
-        "php": "^8.0|^8.1|^8.2",
+        "php": "^8.0|^8.1|^8.2|^8.3|^8.4",
         "spatie/laravel-package-tools": "^1.9.2",
-        "illuminate/contracts": "^9.0|^10.0|^11.0"
+        "illuminate/contracts": "^9.0|^10.0|^11.0|^12.0|^13.0"
     },
     "require-dev": {
         "nunomaduro/collision": "^7.0|^8.0",
-        "orchestra/testbench": "^9.0",
-        "pestphp/pest": "^2.28",
-        "phpunit/phpunit": "^10.0"
+        "orchestra/testbench": "^9.0|^10.0|^11.0",
+        "pestphp/pest": "^2.28|^3.0",
+        "phpunit/phpunit": "^10.0|^11.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
## Summary
- Widen `composer.json` constraints: `illuminate/contracts` now accepts `^12.0|^13.0`, PHP allows `^8.3|^8.4`, `orchestra/testbench` allows up to `^11.0`, and dev tooling allows Pest `^3.0` and PHPUnit `^11.0`.
- Extend the CI matrix in `run-tests.yml` with Laravel 12 (testbench 10) and Laravel 13 (testbench 11), and add PHP 8.4. Laravel 13 is excluded on PHP 8.2 since it requires PHP 8.3+.